### PR TITLE
Fixes incorrect Version Comparison

### DIFF
--- a/src/class_file.rs
+++ b/src/class_file.rs
@@ -81,7 +81,7 @@ impl ClassFileVersion {
     /// second.supports(first); // Returns false because the `first` version is "higher" than the `second` version.
     /// ```
     pub fn supports(&self, other: Self) -> bool {
-        other.major <= self.major && other.minor <= self.minor
+        other.major < self.major || (other.major == self.major && other.minor <= self.minor)
     }
 }
 

--- a/tests/class_file.rs
+++ b/tests/class_file.rs
@@ -1,11 +1,17 @@
 use crate::class_file::ClassFileVersion;
+use rlass::class_file::ClassFileVersion;
 
 #[test]
 fn version_supports_test() {
-    let first = ClassFileVersion::latest();
-    let second = ClassFileVersion::new(52, 0);
+    let first = ClassFileVersion::new(53, 0);
+    let second = ClassFileVersion::new(52, 1);
+    let third = ClassFileVersion::new(52, 0);
 
     assert!(first.supports(second));
+    assert!(first.supports(third));
+    assert!(second.supports(third));
     assert_ne!(second.supports(first));
     assert!(first.supports(first));
+    assert_ne!(third.supports(second));
+    assert_ne!(third.supports(first));
 }

--- a/tests/class_file.rs
+++ b/tests/class_file.rs
@@ -1,4 +1,3 @@
-use crate::class_file::ClassFileVersion;
 use rlass::class_file::ClassFileVersion;
 
 #[test]
@@ -10,8 +9,8 @@ fn version_supports_test() {
     assert!(first.supports(second));
     assert!(first.supports(third));
     assert!(second.supports(third));
-    assert_ne!(second.supports(first));
+    assert!(!second.supports(first));
     assert!(first.supports(first));
-    assert_ne!(third.supports(second));
-    assert_ne!(third.supports(first));
+    assert!(!third.supports(second));
+    assert!(!third.supports(first));
 }


### PR DESCRIPTION
Now ClassFileVersion.supports returns the correct result for versions with lower major version but higher minor version